### PR TITLE
Pin python-installer >=1.0 to match upstream requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2e987a7c11a31e93bc52e8ce111b40459f3f0e03718e09a85daa4ebd670f6cfb
 
 build:
-  skip: true  # [py<39]
+  skip: true  # [py<310]
   # can't be noarch because we can't place EXTERNALLY-MANAGED in stdlib (first level is site-packages)
   number: 1
   script:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<39]
   # can't be noarch because we can't place EXTERNALLY-MANAGED in stdlib (first level is site-packages)
-  number: 0
+  number: 1
   script:
     - set -x  # [unix]
     - "@ECHO ON"  # [win]
@@ -35,7 +35,7 @@ requirements:
     - packaging
     - unearth
     - python-build
-    - python-installer
+    - python-installer >=1.0
     - platformdirs
     - conda-index >=0.7.0
     - conda-rattler-solver >=0.0.6


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please add any other relevant info below:
-->

Align the run requirements with the bound that upstream already declares.

conda-pypi 0.7.1's [`pyproject.toml`](https://github.com/conda/conda-pypi/blob/0.7.1/pyproject.toml) declares `installer >=1.0` / `python-installer = ">=1.0"` because [`conda_pypi/installer.py`](https://github.com/conda/conda-pypi/blob/0.7.1/conda_pypi/installer.py#L52) calls `SchemeDictionaryDestination(..., overwrite_existing=True)`, and the `overwrite_existing` parameter was only added in `installer` 1.0.0. Older versions raise `TypeError: SchemeDictionaryDestination.__init__() got an unexpected keyword argument 'overwrite_existing'`.

This feedstock left `python-installer` unpinned. In practice `python-installer 1.0.0` is on conda-forge and the solver usually selects it, but nothing in the recipe guarantees it — any constraint that pushes the solver toward a pre-1.0 build breaks `conda pypi convert` and anything else that touches `conda_pypi.installer` at runtime.

Changes:

- Pin `python-installer >=1.0` to mirror upstream.
- Raise `skip: true  # [py<39]` → `skip: true  # [py<310]`, since `installer` 1.0.0's [`requires-python = ">=3.10"`](https://github.com/pypa/installer/blob/1.0.0/pyproject.toml#L13) makes py39 unsolvable with the new pin. Also matches the AnacondaRecipes recipe.
- Bump the build number from 0 to 1 since 0.7.1 is already published.

cc @jaimergp @danyeaw @ryanskeith