### PR TITLE
Ship condarc.d/conda-pypi.yml so the short channel name works

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,4 @@ build_env_vars:
 
 channels:
   - https://staging.continuum.io/pbp/fs/unearth-feedstock/pr3/fb7ee3b
+  - https://staging.continuum.io/pbp/fs/conda-rattler-solver-feedstock/pr3/c74c838

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/unearth-feedstock/pr3/fb7ee3b
-  - https://staging.continuum.io/pbp/fs/conda-rattler-solver-feedstock/pr3/c74c838

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/unearth-feedstock/pr3/fb7ee3b

--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,0 +1,4 @@
+anaconda_config_version: 1
+upstream_sources:
+  - pypi:
+      identifier: conda-pypi

--- a/recipe/condarc.d/conda-pypi.yml
+++ b/recipe/condarc.d/conda-pypi.yml
@@ -1,0 +1,2 @@
+custom_channels:
+  conda-pypi: https://repo.anaconda.cloud

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,17 +12,14 @@ source:
 build:
   skip: true  # [py<39]
   # can't be noarch because we can't place EXTERNALLY-MANAGED in stdlib (first level is site-packages)
-  number: 1
+  number: 0
   script:
-    - set -x  # [unix]
+    - set -x      # [unix]
     - "@ECHO ON"  # [win]
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
     - {{ PYTHON }} -c "from conda_pypi.python_paths import ensure_externally_managed; ensure_externally_managed()"
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,17 +25,24 @@ requirements:
     - pip
     - hatchling >=1.12.2
     - hatch-vcs >=0.2.0
+    - importlib_resources  # [py<39]
   run:
     - python
     - conda >=23.9.0
     - pip >=23.0.1
+    - grayskull
+    - importlib_resources  # [py<39]
     - packaging
+    - pydantic >=2.10.0
     - unearth
     - python-build
     - python-installer
+    - requests
+    - ruamel.yaml
+    - typer
     - platformdirs
     - conda-index
-    - conda-libmamba-solver
+    - conda-package-streaming
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-pypi" %}
-{% set version = "0.3.0" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/conda_pypi-{{ version }}.tar.gz
-  sha256: 79d2ba6686ce2c66cd242f8a9e4a2c11824296abad00be48702baf70389f7630
+  sha256: 00ad0a22d7c7b4c71ac04164866d9b36a0acd3ed140ae27378d2ec451dd71452
 
 build:
-  skip: true  # [py<39]
+  skip: true  # [py<310]
   # can't be noarch because we can't place EXTERNALLY-MANAGED in stdlib (first level is site-packages)
   number: 0
   script:
@@ -25,24 +25,17 @@ requirements:
     - pip
     - hatchling >=1.12.2
     - hatch-vcs >=0.2.0
-    - importlib_resources  # [py<39]
   run:
     - python
-    - conda >=23.9.0
+    - conda >=26.1.0
     - pip >=23.0.1
-    - grayskull
-    - importlib_resources  # [py<39]
     - packaging
-    - pydantic >=2.10.0
     - unearth
     - python-build
     - python-installer
-    - requests
-    - ruamel.yaml
-    - typer
     - platformdirs
-    - conda-index
-    - conda-package-streaming
+    - conda-index >=0.7.0
+    - conda-rattler-solver >=0.0.5
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-pypi" %}
-{% set version = "0.4.0" %}
+{% set version = "0.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/conda_pypi-{{ version }}.tar.gz
-  sha256: 00ad0a22d7c7b4c71ac04164866d9b36a0acd3ed140ae27378d2ec451dd71452
+  sha256: 4330b12c0ec90ae7464718bf25af289d51296192c71d8b35843ff41b0a52f061
 
 build:
   skip: true  # [py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<310]
   # can't be noarch because we can't place EXTERNALLY-MANAGED in stdlib (first level is site-packages)
-  number: 0
+  number: 1
   script:
     - set -x      # [unix]
     - "@ECHO ON"  # [win]
@@ -37,6 +37,7 @@ requirements:
     - platformdirs
     - conda-index >=0.7.0
     - conda-rattler-solver >=0.0.5
+    - conda-package-streaming >=0.11
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-pypi" %}
-{% set version = "0.5.0" %}
+{% set version = "0.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/conda_pypi-{{ version }}.tar.gz
-  sha256: 4330b12c0ec90ae7464718bf25af289d51296192c71d8b35843ff41b0a52f061
+  sha256: 9e47f5be2067b3189afc2704e491e522d58cab88ca17549673f6d93559bb40b0
 
 build:
   skip: true  # [py<310]
   # can't be noarch because we can't place EXTERNALLY-MANAGED in stdlib (first level is site-packages)
-  number: 1
+  number: 0
   script:
     - set -x      # [unix]
     - "@ECHO ON"  # [win]
@@ -36,7 +36,7 @@ requirements:
     - python-installer
     - platformdirs
     - conda-index >=0.7.0
-    - conda-rattler-solver >=0.0.5
+    - conda-rattler-solver >=0.0.6
     - conda-package-streaming >=0.11
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/conda_pypi-{{ version }}.tar.gz
-  sha256: 2e987a7c11a31e93bc52e8ce111b40459f3f0e03718e09a85daa4ebd670f6cfb
+  sha256: f8be0d8ab76b1b12ae24b459c5b757f47c9e297f240994da2606759590ab7867
 
 build:
   skip: true  # [py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-pypi" %}
-{% set version = "0.7.1" %}
+{% set version = "0.8.0" %}
 
 package:
   name: {{ name|lower }}
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<310]
   # can't be noarch because we can't place EXTERNALLY-MANAGED in stdlib (first level is site-packages)
-  number: 1
+  number: 0
   script:
     - set -x      # [unix]
     - "@ECHO ON"  # [win]
@@ -35,7 +35,7 @@ requirements:
     - python-build
     - python-installer >=1.0
     - platformdirs
-    - conda-index >=0.7.0
+    - conda-index >=0.11.0
     - conda-rattler-solver >=0.0.6
     - conda-package-streaming >=0.11
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - pip
     - hatchling >=1.12.2
     - hatch-vcs >=0.2.0
+    - python-build
   run:
     - python
     - conda >=26.1.0
@@ -47,14 +48,16 @@ test:
     - python -c "from conda_pypi.python_paths import get_env_stdlib; content = (get_env_stdlib() / 'EXTERNALLY-MANAGED').read_text(); assert '[externally-managed]' in content"
     - python -c "from conda_pypi.python_paths import get_env_stdlib; content = (get_env_stdlib() / 'EXTERNALLY-MANAGED').read_text(); assert 'conda pypi' in content"
     - python -m pip install requests && exit 1 || exit 0
+    - pip check
 
 about:
-  home: https://github.com/conda-incubator/conda-pypi
+  home: https://github.com/conda/conda-pypi
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Better PyPI interoperability for the conda ecosystem
-  dev_url: https://github.com/conda-incubator/conda-pypi
-  doc_url: https://conda-incubator.github.io/conda-pypi
+  dev_url: https://github.com/conda/conda-pypi
+  doc_url: https://conda.github.io/conda-pypi
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<310]
   # can't be noarch because we can't place EXTERNALLY-MANAGED in stdlib (first level is site-packages)
-  number: 0
+  number: 1
   script:
     - set -x      # [unix]
     - "@ECHO ON"  # [win]
@@ -33,7 +33,7 @@ requirements:
     - packaging
     - unearth
     - python-build
-    - python-installer
+    - python-installer >=1.0
     - platformdirs
     - conda-index >=0.7.0
     - conda-rattler-solver >=0.0.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,8 @@ test:
   imports:
     - conda_pypi
     - conda_pypi.main
+  requires:
+    - pip
   commands:
     - python -m conda pypi --help  # Using 'conda pypi'  directly on Windows fails due to the actual 'base' conda being found earlier than test-env's conda
     - python -c "from conda_pypi.python_paths import get_env_stdlib; assert (get_env_stdlib() / 'EXTERNALLY-MANAGED').exists()"
@@ -65,3 +67,8 @@ extra:
     - ryanskeith
     - jaimergp
     - jezdez
+
+skip-lints:
+# conda-pypi needs pip and unearth for conversion
+  - python_build_tool_in_run
+  - python_build_tools_in_host

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-pypi" %}
-{% set version = "0.7.0" %}
+{% set version = "0.7.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/conda_pypi-{{ version }}.tar.gz
-  sha256: e7ace227a796128b9b9659f342b2a761494c5e4a80562713a443177ebc7050ae
+  sha256: 2e987a7c11a31e93bc52e8ce111b40459f3f0e03718e09a85daa4ebd670f6cfb
 
 build:
   skip: true  # [py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-pypi" %}
-{% set version = "0.6.0" %}
+{% set version = "0.7.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/conda_pypi-{{ version }}.tar.gz
-  sha256: 9e47f5be2067b3189afc2704e491e522d58cab88ca17549673f6d93559bb40b0
+  sha256: e7ace227a796128b9b9659f342b2a761494c5e4a80562713a443177ebc7050ae
 
 build:
   skip: true  # [py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,10 @@ build:
     - "@ECHO ON"  # [win]
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
     - {{ PYTHON }} -c "from conda_pypi.python_paths import ensure_externally_managed; ensure_externally_managed()"
+    - mkdir -p "${PREFIX}/condarc.d"                                          # [unix]
+    - cp "${RECIPE_DIR}/condarc.d/conda-pypi.yml" "${PREFIX}/condarc.d/"      # [unix]
+    - mkdir "%PREFIX%\condarc.d"                                              # [win]
+    - copy "%RECIPE_DIR%\condarc.d\conda-pypi.yml" "%PREFIX%\condarc.d\"      # [win]
 
 requirements:
   host:
@@ -50,6 +54,8 @@ test:
     - python -c "from conda_pypi.python_paths import get_env_stdlib; assert (get_env_stdlib() / 'EXTERNALLY-MANAGED').exists()"
     - python -c "from conda_pypi.python_paths import get_env_stdlib; content = (get_env_stdlib() / 'EXTERNALLY-MANAGED').read_text(); assert '[externally-managed]' in content"
     - python -c "from conda_pypi.python_paths import get_env_stdlib; content = (get_env_stdlib() / 'EXTERNALLY-MANAGED').read_text(); assert 'conda pypi' in content"
+    - test -f "${PREFIX}/condarc.d/conda-pypi.yml"                            # [unix]
+    - if not exist "%PREFIX%\condarc.d\conda-pypi.yml" exit 1                 # [win]
     - python -m pip install requests && exit 1 || exit 0
     - pip check
 


### PR DESCRIPTION
## Summary

- Adds a `condarc.d/conda-pypi.yml` config fragment that maps the `conda-pypi` short channel name to `https://repo.anaconda.cloud`, so users can write `conda config --append channels conda-pypi` without the full URL.
- The file is installed into `$PREFIX/condarc.d/` during build and removed automatically when the package is uninstalled.
- Adds a test to verify the config file is present after install.

Alternative to hardcoding `conda-pypi` in conda core's `DEFAULT_CUSTOM_CHANNELS`. See conda/conda-pypi#358.

## Test plan

- [ ] Verify `condarc.d/conda-pypi.yml` exists in the prefix after install
- [ ] Verify `conda config --show custom_channels` includes the `conda-pypi` mapping
- [ ] Verify the file is removed on uninstall