### PR TITLE
Ship condarc.d/conda-pypi.yml so the short channel name works

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,8 @@
+@ECHO ON
+%PYTHON% -m pip install . --no-deps --no-build-isolation -vv
+if errorlevel 1 exit 1
+%PYTHON% -c "from conda_pypi.python_paths import ensure_externally_managed; ensure_externally_managed()"
+if errorlevel 1 exit 1
+mkdir "%PREFIX%\condarc.d"
+copy "%RECIPE_DIR%\condarc.d\conda-pypi.yml" "%PREFIX%\condarc.d\"
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,5 @@
+set -ex
+$PYTHON -m pip install . --no-deps --no-build-isolation -vv
+$PYTHON -c "from conda_pypi.python_paths import ensure_externally_managed; ensure_externally_managed()"
+mkdir -p "${PREFIX}/condarc.d"
+cp "${RECIPE_DIR}/condarc.d/conda-pypi.yml" "${PREFIX}/condarc.d/"

--- a/recipe/condarc.d/conda-pypi.yml
+++ b/recipe/condarc.d/conda-pypi.yml
@@ -1,0 +1,2 @@
+custom_channels:
+  conda-pypi: https://repo.anaconda.cloud

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,15 +13,6 @@ build:
   skip: true  # [py<39]
   # can't be noarch because we can't place EXTERNALLY-MANAGED in stdlib (first level is site-packages)
   number: 0
-  script:
-    - set -x  # [unix]
-    - "@ECHO ON"  # [win]
-    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-    - {{ PYTHON }} -c "from conda_pypi.python_paths import ensure_externally_managed; ensure_externally_managed()"
-    - mkdir -p "${PREFIX}/condarc.d"                                          # [unix]
-    - cp "${RECIPE_DIR}/condarc.d/conda-pypi.yml" "${PREFIX}/condarc.d/"      # [unix]
-    - mkdir "%PREFIX%\condarc.d"                                              # [win]
-    - copy "%RECIPE_DIR%\condarc.d\conda-pypi.yml" "%PREFIX%\condarc.d\"      # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,10 @@ build:
     - "@ECHO ON"  # [win]
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
     - {{ PYTHON }} -c "from conda_pypi.python_paths import ensure_externally_managed; ensure_externally_managed()"
+    - mkdir -p "${PREFIX}/condarc.d"                                          # [unix]
+    - cp "${RECIPE_DIR}/condarc.d/conda-pypi.yml" "${PREFIX}/condarc.d/"      # [unix]
+    - mkdir "%PREFIX%\condarc.d"                                              # [win]
+    - copy "%RECIPE_DIR%\condarc.d\conda-pypi.yml" "%PREFIX%\condarc.d\"      # [win]
 
 requirements:
   build:
@@ -52,6 +56,8 @@ test:
     - python -c "from conda_pypi.python_paths import get_env_stdlib; assert (get_env_stdlib() / 'EXTERNALLY-MANAGED').exists()"
     - python -c "from conda_pypi.python_paths import get_env_stdlib; content = (get_env_stdlib() / 'EXTERNALLY-MANAGED').read_text(); assert '[externally-managed]' in content"
     - python -c "from conda_pypi.python_paths import get_env_stdlib; content = (get_env_stdlib() / 'EXTERNALLY-MANAGED').read_text(); assert 'conda pypi' in content"
+    - test -f "${PREFIX}/condarc.d/conda-pypi.yml"                            # [unix]
+    - if not exist "%PREFIX%\condarc.d\conda-pypi.yml" exit 1                 # [win]
     - python -m pip install requests && exit 1 || exit 0
     - pip check
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered](https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks) with the latest `conda-smithy` (Use the phrase <code>@<!-- -->conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

## Summary

- Adds a `condarc.d/conda-pypi.yml` config fragment that maps the `conda-pypi` short channel name to `https://repo.anaconda.cloud`, so users can write `conda config --append channels conda-pypi` without the full URL.
- The file is installed into `$PREFIX/condarc.d/` during build and removed automatically when the package is uninstalled.
- Moves build logic from inline `meta.yaml` script commands to proper `build.sh`/`bld.bat` files.
- Adds a test to verify the config file is present after install.

Credit to @travishathaway for suggesting the packaging approach. Alternative to hardcoding `conda-pypi` in conda core's `DEFAULT_CUSTOM_CHANNELS`. See conda/conda-pypi#358.

## Test plan

- [ ] Verify `condarc.d/conda-pypi.yml` exists in the prefix after install
- [ ] Verify `conda config --show custom_channels` includes the `conda-pypi` mapping
- [ ] Verify the file is removed on uninstall