### PR TITLE
Move conda to run_constraints to avoid dep cycles in migrations

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
 build:
   # can't be noarch because we can't place EXTERNALLY-MANAGED in stdlib (first level is site-packages)
   # However, EXTERNALLY-MANAGED is temporarily disabled
-  number: 0
+  number: 1
   skip: match(python, "<3.10")
   script:
     - if: unix
@@ -36,7 +36,6 @@ requirements:
     - hatch-vcs >=0.2.0
   run:
     - python
-    - conda >=26.1.0
     - pip >=23.0.1
     - packaging
     - unearth
@@ -45,6 +44,11 @@ requirements:
     - platformdirs
     - conda-index >=0.11.0
     - conda-package-streaming >=0.11
+  run_constraints:
+    # This is technically a `run` dependency (we do import it), but
+    # conda already depends on conda-pypi, so it creates a
+    # dependency cycle that complicates migrations
+    - conda >=26.1.0
 
 tests:
   - python:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
